### PR TITLE
Select css files only to take advantage of caching-writer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
   "undef": true,
+  "unused": true,
   "node" : true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "undef": true,
+  "node" : true
+}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# Split Your CSS With Broccoli
+# Ember CLI CSS Split
 
-Pass your tree to broccoli-csssplit and it will split any
-file (eg. foo.css) with more than 4095 selectors into separate files.
+Splits all `*.css` files with more than 4095 selectors into separate files.
 
-If CSSS continues to run when no CSS files have changed, select specific files using a glob pattern:
+If CSSS tree continues to run via `ember serve`, yet no CSS files have changed:
+
+```
+file changed adapters/application.js
+
+Build successful - 3944ms.
+
+Slowest Trees                  | Total
+-------------------------------+----------------
+CSSS                            | 1214ms
+```
+
+Select specific files using a glob pattern in your ember `Brocfile.js`:
 
 ```js
-// Brocfile.js
 var app = new EmberApp({
   csssplit: {
     files: ['myapp.css', 'themes/*.css']

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-#Split Your CSS With Broccoli
+# Split Your CSS With Broccoli
 
 Pass your tree to broccoli-csssplit and it will split any
 file (eg. foo.css) with more than 4095 selectors into separate files.
+
+If CSSS continues to run when no CSS files have changed, select specific files using a glob pattern:
+
+```js
+// Brocfile.js
+var app = new EmberApp({
+  csssplit: {
+    files: ['myapp.css', 'themes/*.css']
+  }
+});
+```
+
+This will allow `broccoli-caching-writer` to skip processing unless the selected CSS files have changed.

--- a/index.js
+++ b/index.js
@@ -3,30 +3,33 @@
 var path  = require('path');
 var fs    = require('fs');
 var csss  = require('broccoli-csssplit');
-
-function CSSSPlugin(options) {
-  this.name = 'ember-cli-csssplit';
-  this.options = options || {};
-}
-
-CSSSPlugin.prototype.toTree = function(tree) {
-  return csss(tree, this.options);
-};
+var pickFiles  = require('broccoli-static-compiler');
+var mergeTrees  = require('broccoli-merge-trees');
 
 function EmberCLICSSS(project) {
   if (!(this instanceof EmberCLICSSS)) { return new EmberCLICSSS(project); }
   this.project = project;
-  this.name    = 'Ember CLI CSSS';
+  this.name    = 'ember-cli-csssplit';
 }
 
 EmberCLICSSS.prototype.treeFor = function treeFor() {
 };
 
 EmberCLICSSS.prototype.included = function included(app) {
+  this.app     = app;
+  this.options = this.app.options.csssplit || {};
 };
 
 EmberCLICSSS.prototype.postprocessTree = function(type, tree) {
-  return csss(tree, this.options);
-}
+  var files = this.options.files || ['**/*.css'];
+
+  var styles = pickFiles(tree, {
+    srcDir: '/assets',
+    files: files,
+    destDir: '/assets'
+  });
+
+  return csss(styles, this.options);
+};
 
 module.exports = EmberCLICSSS;

--- a/index.js
+++ b/index.js
@@ -1,19 +1,13 @@
 'use strict';
 
-var path  = require('path');
-var fs    = require('fs');
 var csss  = require('broccoli-csssplit');
 var pickFiles  = require('broccoli-static-compiler');
-var mergeTrees  = require('broccoli-merge-trees');
 
 function EmberCLICSSS(project) {
   if (!(this instanceof EmberCLICSSS)) { return new EmberCLICSSS(project); }
   this.project = project;
   this.name    = 'ember-cli-csssplit';
 }
-
-EmberCLICSSS.prototype.treeFor = function treeFor() {
-};
 
 EmberCLICSSS.prototype.included = function included(app) {
   this.app     = app;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "before": "broccoli-asset-rev"
   },
   "dependencies": {
-    "broccoli-csssplit": "^0.0.8"
+    "broccoli-csssplit": "^0.0.8",
+    "broccoli-merge-trees": "^0.1.4",
+    "broccoli-static-compiler": "^0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "broccoli-csssplit": "^0.0.8",
-    "broccoli-merge-trees": "^0.1.4",
     "broccoli-static-compiler": "^0.1.4"
   }
 }


### PR DESCRIPTION
Don't merge this until you've bumped the version on `broccoli-csssplit`, so that we can add it to this repos `package.json`
