### PR TITLE
Merge CSS split files back into master tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var csss  = require('broccoli-csssplit');
 var pickFiles  = require('broccoli-static-compiler');
+var mergeTrees  = require('broccoli-merge-trees');
 
 function EmberCLICSSS(project) {
   if (!(this instanceof EmberCLICSSS)) { return new EmberCLICSSS(project); }
@@ -23,7 +24,7 @@ EmberCLICSSS.prototype.postprocessTree = function(type, tree) {
     destDir: '/assets'
   });
 
-  return csss(styles, this.options);
+  return mergeTrees([tree, csss(styles, this.options)], { overwrite: true });
 };
 
 module.exports = EmberCLICSSS;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "broccoli-csssplit": "^0.0.8",
+    "broccoli-merge-trees": "^0.1.4",
     "broccoli-static-compiler": "^0.1.4"
   }
 }


### PR DESCRIPTION
Forgot to merge the CSS split files back into the main tree.. This causes the output dir to contain inly css files and splits! :warning: 
